### PR TITLE
Optimize loops for V8 Smi

### DIFF
--- a/adler32.flow.js
+++ b/adler32.flow.js
@@ -36,7 +36,7 @@ function adler32_bstr(bstr/*:string*/, seed/*:?ADLER32Type*/)/*:ADLER32Type*/ {
 	var a = 1, b = 0, L = bstr.length, M = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = seed >>> 16; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += bstr.charCodeAt(i)&0xFF;
 			b += a;
@@ -51,7 +51,7 @@ function adler32_buf(buf/*:ABuf*/, seed/*:?ADLER32Type*/)/*:ADLER32Type*/ {
 	var a = 1, b = 0, L = buf.length, M = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = (seed >>> 16) & 0xFFFF; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += buf[i]&0xFF;
 			b += a;
@@ -67,7 +67,7 @@ function adler32_str(str/*:string*/, seed/*:?ADLER32Type*/)/*:ADLER32Type*/ {
 	var a = 1, b = 0, L = str.length, M = 0, c = 0, d = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = seed >>> 16; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850);
+		M = Math.min(L-i, 2918);
 		while(M>0) {
 			c = str.charCodeAt(i++);
 			if(c < 0x80) { a += c; }

--- a/adler32.js
+++ b/adler32.js
@@ -28,7 +28,7 @@ function adler32_bstr(bstr, seed) {
 	var a = 1, b = 0, L = bstr.length, M = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = seed >>> 16; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += bstr.charCodeAt(i)&0xFF;
 			b += a;
@@ -43,7 +43,7 @@ function adler32_buf(buf, seed) {
 	var a = 1, b = 0, L = buf.length, M = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = (seed >>> 16) & 0xFFFF; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += buf[i]&0xFF;
 			b += a;
@@ -58,7 +58,7 @@ function adler32_str(str, seed) {
 	var a = 1, b = 0, L = str.length, M = 0, c = 0, d = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = seed >>> 16; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850);
+		M = Math.min(L-i, 2918);
 		while(M>0) {
 			c = str.charCodeAt(i++);
 			if(c < 0x80) { a += c; }

--- a/bits/40_adler.js
+++ b/bits/40_adler.js
@@ -4,7 +4,7 @@ function adler32_bstr(bstr/*:string*/, seed/*:?ADLER32Type*/)/*:ADLER32Type*/ {
 	var a = 1, b = 0, L = bstr.length, M = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = seed >>> 16; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += bstr.charCodeAt(i)&0xFF;
 			b += a;
@@ -19,7 +19,7 @@ function adler32_buf(buf/*:ABuf*/, seed/*:?ADLER32Type*/)/*:ADLER32Type*/ {
 	var a = 1, b = 0, L = buf.length, M = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = (seed >>> 16) & 0xFFFF; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += buf[i]&0xFF;
 			b += a;
@@ -35,7 +35,7 @@ function adler32_str(str/*:string*/, seed/*:?ADLER32Type*/)/*:ADLER32Type*/ {
 	var a = 1, b = 0, L = str.length, M = 0, c = 0, d = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = seed >>> 16; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850);
+		M = Math.min(L-i, 2918);
 		while(M>0) {
 			c = str.charCodeAt(i++);
 			if(c < 0x80) { a += c; }

--- a/ctest/adler32.js
+++ b/ctest/adler32.js
@@ -28,7 +28,7 @@ function adler32_bstr(bstr, seed) {
 	var a = 1, b = 0, L = bstr.length, M = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = seed >>> 16; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += bstr.charCodeAt(i)&0xFF;
 			b += a;
@@ -43,7 +43,7 @@ function adler32_buf(buf, seed) {
 	var a = 1, b = 0, L = buf.length, M = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = (seed >>> 16) & 0xFFFF; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += buf[i]&0xFF;
 			b += a;
@@ -58,7 +58,7 @@ function adler32_str(str, seed) {
 	var a = 1, b = 0, L = str.length, M = 0, c = 0, d = 0;
 	if(typeof seed === 'number') { a = seed & 0xFFFF; b = seed >>> 16; }
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850);
+		M = Math.min(L-i, 2918);
 		while(M>0) {
 			c = str.charCodeAt(i++);
 			if(c < 0x80) { a += c; }

--- a/perf/bstr.js
+++ b/perf/bstr.js
@@ -15,7 +15,7 @@ function sheetjs1(bstr) {
 function sheetjs2(bstr) {
 	var a = 1, b = 0, L = bstr.length, M = 0;
 	for(var i = 0; i < L;) {
-		M = Math.min(L-i, 3850)+i;
+		M = Math.min(L-i, 2654)+i;
 		for(;i<M;i++) {
 			a += bstr.charCodeAt(i);
 			b += a;
@@ -27,6 +27,20 @@ function sheetjs2(bstr) {
 }
 
 function sheetjs3(bstr) {
+	var a = 1, b = 0, L = bstr.length, M = 0;
+	for(var i = 0; i < L;) {
+		M = Math.min(L-i, 3850)+i;
+		for(;i<M;i++) {
+			a += bstr.charCodeAt(i);
+			b += a;
+		}
+		a = (15*(a>>>16)+(a&65535))
+		b = (15*(b>>>16)+(b&65535))
+	}
+	return ((b%65521) << 16) | (a%65521);
+}
+
+function sheetjs4(bstr) {
 	var a = 1, b = 0, L = bstr.length, M = 0;
 	for(var i = 0; i < L;) {
 		M = Math.min(L-i, 5552);
@@ -58,11 +72,13 @@ for(var i = 6; i != 14; ++i) {
 	assert.equal(res, sheetjs1(foobar));
 	assert.equal(res, sheetjs2(foobar));
 	assert.equal(res, sheetjs3(foobar));
+	assert.equal(res, sheetjs4(foobar));
 
 	var suite = new BM('binary string (' + foobar.length + ')');
 	if(i<3) suite.add('sheetjs 1', function() { for(var j = 0; j != m; ++j) sheetjs1(foobar); });
 	suite.add('sheetjs 2', function() { for(var j = 0; j != m; ++j) sheetjs2(foobar); });
 	suite.add('sheetjs 3', function() { for(var j = 0; j != m; ++j) sheetjs3(foobar); });
+	suite.add('sheetjs 4', function() { for(var j = 0; j != m; ++j) sheetjs4(foobar); });
 	suite.add('last vers', function() { for(var j = 0; j != m; ++j) old(foobar); });
 	suite.add('current v', function() { for(var j = 0; j != m; ++j) cur(foobar); });
 	suite.run();

--- a/perf/utf8.js
+++ b/perf/utf8.js
@@ -19,6 +19,64 @@ function sheetjs1(utf8) {
 function sheetjs2(utf8) {
 	var a = 1, b = 0, L = utf8.length, M, c, d;
 	for(var i = 0; i < L;) {
+		M = Math.min(L-i, 2654);
+		while(M>0) {
+			c = utf8.charCodeAt(i++);
+			if(c < 0x80) {
+				a += c; b += a; --M;
+			} else if(c < 0x800) {
+				a += 192|((c>>6)&31);             b += a; --M;
+				a += 128|(c&63);                  b += a; --M;
+			} else if(c >= 0xD800 && c < 0xE000) {
+				c = (c&1023)+64; d = utf8.charCodeAt(i++) & 1023;
+				a += 240|((c>>8)&7);              b += a; --M;
+				a += 128|((c>>2)&63);             b += a; --M;
+				a += 128|((d>>6)&15)|((c&3)<<4);  b += a; --M;
+				a += 128|(d&63);                  b += a; --M;
+			} else {
+				a += 224|((c>>12)&15);            b += a; --M;
+				a += 128|((c>>6)&63);             b += a; --M;
+				a += 128|(c&63);                  b += a; --M;
+			}
+		}
+		a %= 65521;
+		b %= 65521;
+	}
+	return (b << 16) | a;
+}
+
+function sheetjs3(utf8) {
+	var a = 1, b = 0, L = utf8.length, M, c, d;
+	for(var i = 0; i < L;) {
+		M = Math.min(L-i, 2918);
+		while(M>0) {
+			c = utf8.charCodeAt(i++);
+			if(c < 0x80) {
+				a += c; b += a; --M;
+			} else if(c < 0x800) {
+				a += 192|((c>>6)&31);             b += a; --M;
+				a += 128|(c&63);                  b += a; --M;
+			} else if(c >= 0xD800 && c < 0xE000) {
+				c = (c&1023)+64; d = utf8.charCodeAt(i++) & 1023;
+				a += 240|((c>>8)&7);              b += a; --M;
+				a += 128|((c>>2)&63);             b += a; --M;
+				a += 128|((d>>6)&15)|((c&3)<<4);  b += a; --M;
+				a += 128|(d&63);                  b += a; --M;
+			} else {
+				a += 224|((c>>12)&15);            b += a; --M;
+				a += 128|((c>>6)&63);             b += a; --M;
+				a += 128|(c&63);                  b += a; --M;
+			}
+		}
+		a %= 65521;
+		b %= 65521;
+	}
+	return (b << 16) | a;
+}
+
+function sheetjs4(utf8) {
+	var a = 1, b = 0, L = utf8.length, M, c, d;
+	for(var i = 0; i < L;) {
 		M = Math.min(L-i, 3850);
 		while(M>0) {
 			c = utf8.charCodeAt(i++);
@@ -53,11 +111,16 @@ var res = old(foobar);
 assert.equal(res, cur(foobar));
 assert.equal(res, sheetjs1(foobar));
 assert.equal(res, sheetjs2(foobar));
+assert.equal(res, sheetjs3(foobar));
+assert.equal(res, sheetjs4(foobar));
+
 
 var BM = require('./bm');
 var suite = new BM('unicode string');
 suite.add('sheetjs 1', function() { for(var j = 0; j != 1000; ++j) sheetjs1(foobar); });
 suite.add('sheetjs 2', function() { for(var j = 0; j != 1000; ++j) sheetjs2(foobar); });
+suite.add('sheetjs 3', function() { for(var j = 0; j != 1000; ++j) sheetjs3(foobar); });
+suite.add('sheetjs 4', function() { for(var j = 0; j != 1000; ++j) sheetjs4(foobar); });
 suite.add('last vers', function() { for(var j = 0; j != 1000; ++j) old(foobar); });
 suite.add('current v', function() { for(var j = 0; j != 1000; ++j) cur(foobar); });
 suite.run();


### PR DESCRIPTION
This PR modifies the number of iterations that the Adler32 algorithm uses before taking a modulus. The magic numbers were the maximum values that will always ensure `B < 2 ** 30 - 1`, since that's the largest value that fits in a V8 small integer.

```
# The magic number we want to find
N = ?
# Maximum possible average value of bytes
# 255 for binary, 207 for UTF-8
M = ?

# maximum initial value of A
# Takes the modulus-but-not-really algorithm into account
# Subtract 1 because will not be able to get 65535 modulo
# 65536 unless we go below the previous 16-bit boundary
A = 15 * ((N * M >> 16) - 1) + 65535

# max initial value of B (assuming previously hit max)
# This isn't perfectly accurate, in theory we should replace
# 2 ** 30 - 1 with B_max but in practice they are close enough
B = 15 * ((2 ** 30 - 1 >> 16) - 1) + 65535

# Try to make this as close to 2 ** 30 - 1 without surpassing
B_max = B + N * A + (N * (N + 1) / 2) * M
```

This yields N = 2654 for binary and N = 2918 for UTF-8.

If you're wondering why UTF-8 has a maximum average byte value of 207, consider that only one of the four following code point structures are possible:
```
0bbbbbbb
110bbbbb 10bbbbbb
1110bbbb 10bbbbbb 10bbbbbb
11110bbb 10bbbbbb 10bbbbbb 10bbbbbb
```
If we check the maximum value for each code point (i.e. set all the `b` placeholders to 1), we find 127 for the 1-byte variant, 414 for the 2-byte, 621 for the 3-byte, and 820 for the 4-byte. This yields a maximum value of 127/byte, 207/byte, 207/byte, and 205/byte for 1, 2, 3, and 4-byte codes respectively. Taking the max of this, the average value of all bytes in a UTF-8 sequences maxes out at 207, and will almost always be in the low to mid 100s in practice.

I also updated the benchmarks, but my computer doesn't reveal any major differences between any of the magic numbers (though at least now the values are semantically correct).

Hope you find these optimizations useful!