### PR TITLE
Support "make test" without Mocha installed globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ node_js:
   - "0.8"
 before_install:
   - "npm install -g npm@4.3.0"
-  - "npm install -g mocha@2.x voc"
+  - "npm install -g voc"
   - "npm install codepage"
   - "npm install blanket"
   - "npm install coveralls mocha-lcov-reporter"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean: clean-baseline ## Remove targets and build artifacts
 
 .PHONY: test mocha
 test mocha: test.js $(TARGET) baseline ## Run test suite
-	mocha -R spec -t 60000
+	./node_modules/.bin/mocha -R spec -t 60000
 
 .PHONY: ctest
 ctest: ## Build browser test (into ctest/ subdirectory)
@@ -88,11 +88,11 @@ flow: lint ## Run flow checker
 cov: misc/coverage.html ## Run coverage test
 
 misc/coverage.html: $(TARGET) test.js
-	mocha --require blanket -R html-cov -t 30000 > $@
+	./node_modules/.bin/mocha --require blanket -R html-cov -t 30000 > $@
 
 .PHONY: coveralls
 coveralls: ## Coverage Test + Send to coveralls.io
-	mocha --require blanket --reporter mocha-lcov-reporter -t 20000 | node ./node_modules/coveralls/bin/coveralls.js
+	./node_modules/.bin/mocha --require blanket --reporter mocha-lcov-reporter -t 20000 | node ./node_modules/coveralls/bin/coveralls.js
 
 MDLINT=README.md
 .PHONY: mdlint


### PR DESCRIPTION
Since it is already included as a dev-dependency, we can just use the bundled version instead of requiring Mocha to be installed globally.