### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
 	"keywords": [ "adler32", "checksum" ],
 	"main": "./adler32",
 	"types": "types",
-	"dependencies": {
-		"printj": "~1.2.2"
-	},
 	"devDependencies": {
 		"mocha": "~2.5.3",
 		"blanket": "~1.2.3",


### PR DESCRIPTION
The printj dependency is used only by the CLI, which has been moved to the adler32-cli package.